### PR TITLE
[SHRS-15] Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
   "license": "ISC",
   "dependencies": {
     "awilix": "7.0.3",
-    "graphql": "16.5.0",
+    "graphql": "16.6.0",
     "jsonwebtoken": "8.5.1"
   },
   "devDependencies": {
     "@types/jest": "27.5.1",
-    "@types/jsonwebtoken": "8.5.8",
+    "@types/jsonwebtoken": "8.5.9",
     "@types/node": "17.0.35",
-    "eslint": "8.16.0",
+    "eslint": "8.23.1",
     "husky": "8.0.1",
     "jest": "28.1.0",
     "standard": "17.0.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -10,30 +10,30 @@
   },
   "dependencies": {
     "@apollo/client": "3.6.9",
-    "@uppy/core": "2.3.1",
-    "@uppy/image-editor": "1.3.0",
-    "@uppy/react": "2.2.2",
-    "@uppy/xhr-upload": "2.1.2",
+    "@uppy/core": "3.0.1",
+    "@uppy/image-editor": "2.0.0",
+    "@uppy/react": "3.0.1",
+    "@uppy/xhr-upload": "3.0.1",
     "cookie": "0.5.0",
-    "next": "12.2.0",
+    "next": "12.3.0",
     "next-themes": "0.2.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-hook-form": "7.33.0",
+    "react-hook-form": "7.35.0",
     "react-select": "5.4.0",
-    "react-toastify": "9.0.5",
+    "react-toastify": "9.0.8",
     "react-waypoint": "10.3.0",
-    "sweetalert2": "11.4.18",
+    "sweetalert2": "11.4.32",
     "react-simple-star-rating": "3.0.0"
   },
   "devDependencies": {
-    "@types/react": "18.0.15",
+    "@types/react": "18.0.19",
     "@types/react-dom": "18.0.6",
     "@types/cookie": "0.5.1",
-    "autoprefixer": "10.4.7",
+    "autoprefixer": "10.4.9",
     "elliptic": "6.5.4",
-    "postcss": "8.4.14",
+    "postcss": "8.4.16",
     "postcss-cli": "10.0.0",
-    "tailwindcss": "3.1.4"
+    "tailwindcss": "3.1.8"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,29 +16,29 @@
   "devDependencies": {
     "@types/bcrypt": "5.0.0",
     "@types/express": "4.17.13",
-    "@types/lodash": "4.14.182",
+    "@types/lodash": "4.14.185",
     "@types/module-alias": "^2.0.1",
     "@types/multer": "1.4.7",
     "@types/nodemailer": "6.4.4",
     "@types/supertest": "2.0.12",
     "@types/uuid": "8.3.4",
-    "nodemon": "2.0.17",
-    "supertest": "6.2.3",
+    "nodemon": "2.0.19",
+    "supertest": "6.2.4",
     "ts-node-dev": "1.1.8",
     "tsconfig-paths": "3.14.1"
   },
   "dependencies": {
-    "apollo-server-core": "3.9.0",
-    "apollo-server-express": "3.9.0",
+    "apollo-server-core": "3.10.2",
+    "apollo-server-express": "3.10.2",
     "bcrypt": "5.0.1",
     "cors": "2.8.5",
-    "dotenv": "16.0.1",
+    "dotenv": "16.0.2",
     "express": "4.18.1",
     "lodash": "4.17.21",
     "module-alias": "2.2.2",
-    "mongoose": "6.4.0",
+    "mongoose": "6.6.0",
     "multer": "1.4.5-lts.1",
-    "nodemailer": "6.7.5",
-    "uuid": "8.3.2"
+    "nodemailer": "6.7.8",
+    "uuid": "9.0.0"
   }
 }


### PR DESCRIPTION
Common dependencies:
- [x] graphql to v16.6.0

Common devDeps:
- [x] @types/jsonwebtoken to v8.5.9
- [x] eslint to v8.23.1

Frontend dependencies:
- [x] @uppy/core to v3.0.1
- [x] @uppy/image-editor to v2.0.0
- [x] @uppy/react to v3.0.1
- [x] @uppy/xhr-upload to v3.0.1
- [x] next to v12.3.0
- [x] react-hook-form to v7.35.0
- [x] react-toastify to v9.0.8
- [x] sweetalert2 to v11.4.32

Frontend devDeps:
- [x] @types/react to v18.0.19
- [x] autoprefixer to v10.4.9
- [x] postcss to v8.4.16
- [x] tailwindcss to v3.1.8

Server dependencies:
- [x] apollo-server-core to v3.10.2
- [x] apollo-server-express to v3.10.2
- [x] dotenv to v16.0.2
- [x] mongoose to v6.6.0
- [x] nodemailer to v6.7.8
- [x] uuid to v9.0.0

Server devDeps:
- [x] @types/lodash to v4.14.185
- [x] nodemon to v2.0.19
- [x] supertest to v6.2.4